### PR TITLE
Potential fix for code scanning alert no. 85: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ module.exports = function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/pullakarthiksrivastav/juice-shop/security/code-scanning/85](https://github.com/pullakarthiksrivastav/juice-shop/security/code-scanning/85)

The best way to fix this problem is to avoid using the `$where` operator with user-provided input. Instead, use a parameterized query to safely include the user input in the query. This approach prevents the execution of arbitrary JavaScript code and mitigates the risk of code injection.

To implement this fix, we need to change the query on line 18 to use a parameterized query. Specifically, we should use the `find` method with a query object that directly compares the `orderId` field to the sanitized `id` value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
